### PR TITLE
Update ChatboxBot.html

### DIFF
--- a/ChatboxBot.html
+++ b/ChatboxBot.html
@@ -185,9 +185,9 @@
       }
     }
 
-    function escapeRegex(string) {
+    /*function escapeRegex(string) { //Unneeded, keeping for preservation
       return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-    }
+    }*/
 
     const chatlogNode = document.querySelector("#chatlog")
     const msgTemplate = document.querySelector("#chatmessage")
@@ -266,23 +266,46 @@
         }
       }
 
-      /*
-      * EMOTES
-      */
-      try {
-        let msgWithEmotes = msg
-        const emotes = context["emotes"]
-        for (const emote in emotes) {
-          const emoteImgSrc = `https://static-cdn.jtvnw.net/emoticons/v2/${emote}/default/dark/1.0`
-          const firstEmoteOccurance = emotes[emote][0].split("-")
-          const emoteString = msg.substring(parseInt(firstEmoteOccurance[0]), parseInt(firstEmoteOccurance[1]) + 1)
-          const emoteImg = `<span class="emote"><img src="${emoteImgSrc}" alt="${emoteString}"></span>`
-          msgWithEmotes = msgWithEmotes.replace(new RegExp(escapeRegex(emoteString), 'g'), emoteImg)
+        /*
+        * EMOTES
+        */
+        try { 
+          let msgWithEmotes = msg.split(" ");
+          let fragment = "";
+          const emotes = context["emotes"]
+           for(let i = 0; i < msgWithEmotes.length; i++) {
+              let emoteChecked = false;
+              for (const emote in emotes) {//TODO: Make this simpler?
+                const firstEmoteOccurance = emotes[emote][0].split("-")
+                const emoteString = msg.substring(parseInt(firstEmoteOccurance[0]), parseInt(firstEmoteOccurance[1]) + 1)
+                if(emoteString == msgWithEmotes[i]){
+                  const emoteImgSrc = `https://static-cdn.jtvnw.net/emoticons/v2/${emote}/default/dark/1.0`
+                  let text = document.createElement('span');
+                  text.innerText = fragment;
+                  messageNode.querySelector(".message").appendChild(text);
+                  fragment = ""; //dump the text fragment because we need to append a new span
+                  const emoteImg = `<img src="${emoteImgSrc}" alt="${emoteString}">`
+                  const emoteSpan = document.createElement('span');
+                  emoteSpan.className = "emote"
+                  emoteSpan.innerHTML = emoteImg;
+                  messageNode.querySelector(".message").appendChild(emoteSpan);
+                  emoteChecked = true;
+                }
+              } 
+            if(!emoteChecked){
+              fragment += `${msgWithEmotes[i]} `
+              console.log(fragment);
+            }
+            if(i == msgWithEmotes.length - 1) { // arrays start at 0
+              let text = document.createElement('span');
+              text.innerText = fragment;
+              messageNode.querySelector(".message").appendChild(text);
+            }
+          }
+
+        } catch (error) {
+          messageNode.querySelector(".message").innerText = msg
         }
-        messageNode.querySelector(".message").innerHTML = msgWithEmotes
-      } catch (error) {
-        messageNode.querySelector(".message").innerHTML = msg
-      }
 
 
       // Add message

--- a/ChatboxBot.html
+++ b/ChatboxBot.html
@@ -275,15 +275,17 @@
           const emotes = context["emotes"]
            for(let i = 0; i < msgWithEmotes.length; i++) {
               let emoteChecked = false;
-              for (const emote in emotes) {//TODO: Make this simpler?
+              for (const emote in emotes) {
                 const firstEmoteOccurance = emotes[emote][0].split("-")
                 const emoteString = msg.substring(parseInt(firstEmoteOccurance[0]), parseInt(firstEmoteOccurance[1]) + 1)
                 if(emoteString == msgWithEmotes[i]){
                   const emoteImgSrc = `https://static-cdn.jtvnw.net/emoticons/v2/${emote}/default/dark/1.0`
-                  let text = document.createElement('span');
-                  text.innerText = fragment;
-                  messageNode.querySelector(".message").appendChild(text);
-                  fragment = ""; //dump the text fragment because we need to append a new span
+                  if(fragment !== ""){
+                    let text = document.createElement('span');
+                    text.innerText = fragment;
+                    messageNode.querySelector(".message").appendChild(text);
+                    fragment = ""; //dump the text fragment because we need to append a new span
+                  }
                   const emoteImg = `<img src="${emoteImgSrc}" alt="${emoteString}">`
                   const emoteSpan = document.createElement('span');
                   emoteSpan.className = "emote"

--- a/ChatboxBot.html
+++ b/ChatboxBot.html
@@ -272,6 +272,7 @@
         try { 
           let msgWithEmotes = msg.split(" ");
           let fragment = "";
+          let messageNodeClass = messageNode.querySelector(".message")
           const emotes = context["emotes"]
            for(let i = 0; i < msgWithEmotes.length; i++) {
               let emoteChecked = false;
@@ -283,14 +284,14 @@
                   if(fragment !== ""){
                     let text = document.createElement('span');
                     text.innerText = fragment;
-                    messageNode.querySelector(".message").appendChild(text);
+                    messageNodeClass.appendChild(text);
                     fragment = ""; //dump the text fragment because we need to append a new span
                   }
                   const emoteImg = `<img src="${emoteImgSrc}" alt="${emoteString}">`
                   const emoteSpan = document.createElement('span');
                   emoteSpan.className = "emote"
                   emoteSpan.innerHTML = emoteImg;
-                  messageNode.querySelector(".message").appendChild(emoteSpan);
+                  messageNodeClass.appendChild(emoteSpan);
                   emoteChecked = true;
                 }
               } 
@@ -301,12 +302,12 @@
             if(i == msgWithEmotes.length - 1) { // arrays start at 0
               let text = document.createElement('span');
               text.innerText = fragment;
-              messageNode.querySelector(".message").appendChild(text);
+              messageNodeClass.appendChild(text);
             }
           }
 
         } catch (error) {
-          messageNode.querySelector(".message").innerText = msg
+          messageNodeClass.innerText = msg
         }
 
 


### PR DESCRIPTION
Change emote handling to innertext for non emotes and img for emotes to fix the invalid tag issue I found.

I redid the emote handling to be a bit closer to how twitch handles it on the website end. Anything that is strictly text will go to its own span, be split by an emote, and then a new span started. This also fixes text rendering for any symbols that would be regarded as html characters using innerText. I also eliminated the need for using a regex.